### PR TITLE
Create unused binding optimisation

### DIFF
--- a/packages/compiler/src/api.ts
+++ b/packages/compiler/src/api.ts
@@ -1,3 +1,4 @@
+import { removeUnusedBindings } from './optimisations/remove-unused-bindings/remove-unused-bindings';
 import parse from './parser/parse';
 import { evaluationScope } from './type-checker/constructors';
 import { evaluateExpression } from './type-checker/evaluate';
@@ -23,10 +24,11 @@ export function compile(code: string): CompileResult {
   }
 
   const [typeMessages, typedNode] = runTypePhase(expression);
+  const optimizedNode = removeUnusedBindings(typedNode);
 
   return {
-    expression: stripNode(typedNode),
-    node: typedNode,
+    expression: stripNode(optimizedNode),
+    node: optimizedNode,
     messages: typeMessages,
   };
 }

--- a/packages/compiler/src/optimisations/remove-unused-bindings/remove-unused-bindings.test.ts
+++ b/packages/compiler/src/optimisations/remove-unused-bindings/remove-unused-bindings.test.ts
@@ -1,0 +1,29 @@
+import dedent from "dedent-js";
+import { stripNode, Expression } from '../..';
+import { compile } from '../../api';
+
+describe('removeUnusedBindings', () => {
+  it('removes binding expressions that are not used', () => {
+    const result = compile(dedent`
+      let a = 1
+      let b = 2
+      a
+    `);
+    expect(result.node).toBeDefined();
+    if (result.node) {
+      const expected: Expression = {
+        kind: 'BindingExpression',
+        name: 'a',
+        value: {
+          kind: 'NumberExpression',
+          value: 1,
+        },
+        body: {
+          kind: 'Identifier',
+          name: 'a',
+        },
+      };
+      expect(stripNode(result.node)).toEqual(expected);
+    }
+  });
+});

--- a/packages/compiler/src/optimisations/remove-unused-bindings/remove-unused-bindings.ts
+++ b/packages/compiler/src/optimisations/remove-unused-bindings/remove-unused-bindings.ts
@@ -1,0 +1,42 @@
+import { TypedNode, Expression, NodeWithChild } from '../..';
+import { TypedDecoration } from '../../type-checker/type-check';
+import {
+  visitAndTransformChildExpression,
+  visitAndTransformNode,
+  visitNodes,
+} from '../../type-checker/visitor-utils';
+
+interface TypeAndBindingDecoration {
+  type: TypedDecoration;
+  bindings: string[];
+}
+
+function removedUnusedBindingsVisitor(node: NodeWithChild<TypedDecoration, [string[], TypedNode]>): [string[], TypedNode] {
+  if (node.expression.kind === 'BindingExpression') {
+    const [variables] = node.expression.body;
+    if (!variables.includes(node.expression.name)) {
+      return node.expression.body;
+    }
+  }
+
+  let allVariables: string[] = [];
+  const expression = visitAndTransformChildExpression<[string[], TypedNode], TypedNode>(
+    ([variables, node]) => {
+      allVariables = allVariables.concat(variables);
+      return node;
+    },
+  )(node.expression);
+
+  if (expression.kind === 'Identifier') {
+    allVariables.push(expression.name);
+  }
+
+  return [allVariables, { ...node, expression }];
+}
+
+export function removeUnusedBindings(node: TypedNode): TypedNode {
+  const [_, resultNode] = visitAndTransformNode<TypedDecoration, [string[], TypedNode]>(
+    removedUnusedBindingsVisitor
+  )(node);
+  return resultNode;
+}

--- a/packages/compiler/src/type-checker/types/node.ts
+++ b/packages/compiler/src/type-checker/types/node.ts
@@ -6,6 +6,12 @@ export interface Node<T> {
   decoration: T;
 }
 
+export interface NodeWithChild<T, C> {
+  kind: 'Node';
+  expression: Expression<C>;
+  decoration: T;
+}
+
 export function getDecoration<T>(node: Node<T>): T {
   return node.decoration;
 }

--- a/packages/compiler/src/type-checker/visitor-utils.ts
+++ b/packages/compiler/src/type-checker/visitor-utils.ts
@@ -1,6 +1,7 @@
 import { mapValues } from 'lodash';
 import { TypedNode } from './type-check';
 import { Expression } from './types/expression';
+import { Node, NodeWithChild } from './types/node';
 import { Value } from './types/value';
 import { assertNever } from './utils';
 
@@ -29,7 +30,7 @@ interface Visitor<T> {
   after?(t: T): T;
 }
 
-export const visitExpressionNodes = (visitor: Visitor<TypedNode>) => (expression: Expression<TypedNode>): Expression<TypedNode> => {
+export const visitExpressionNodes = <T>(visitor: Visitor<Node<T>>) => (expression: Expression<Node<T>>): Expression<Node<T>> => {
   switch (expression.kind) {
     case 'SymbolExpression':
     case 'BooleanExpression':
@@ -105,7 +106,7 @@ export const visitExpressionNodes = (visitor: Visitor<TypedNode>) => (expression
   }
 };
 
-export const visitNodes = (visitor: Visitor<TypedNode>) => (node: TypedNode): TypedNode => {
+export const visitNodes = <T>(visitor: Visitor<Node<T>>) => (node: Node<T>): Node<T> => {
   const beforeNode = visitor.before?.(node) || node;
   const transformedNode = {
     ...node,
@@ -114,7 +115,12 @@ export const visitNodes = (visitor: Visitor<TypedNode>) => (node: TypedNode): Ty
   return visitor.after?.(transformedNode) || transformedNode;
 };
 
-const visitAndTransformChildExpression = <T>(callback: (expression: Expression) => T extends void ? Expression : T) => (expression: Expression): Expression<T> => {
+export const visitAndTransformNode = <D, B>(visitor: (value: NodeWithChild<D, B>) => B extends void ? Expression : B) => (node: Node<D>): B extends void ? Expression : B => {
+  const expression = visitAndTransformChildExpression(visitAndTransformNode(visitor))(node.expression);
+  return visitor({ ...node, expression });
+};
+
+export const visitAndTransformChildExpression = <A, T>(callback: (expression: A extends void ? Expression : A) => T extends void ? Expression : T) => (expression: Expression<A>): Expression<T> => {
   switch (expression.kind) {
     case 'SymbolExpression':
     case 'BooleanExpression':


### PR DESCRIPTION
Removes unused bindings from the AST before translating the code into Javascript. This is required for the Prelude library work to be satisfactory.

Part of #27 