### PR TITLE
Remove persistent unique ids

### DIFF
--- a/packages/compiler/src/backend/javascript/generate-javascript.test.ts
+++ b/packages/compiler/src/backend/javascript/generate-javascript.test.ts
@@ -29,15 +29,15 @@ describe('generateJavascript', () => {
   });
 
   it('translates a function expression', () => {
-    expect(toJavascript('a -> b -> 1')).toEqual('export default (a$rename$79 => b$rename$80 => 1);');
+    expect(toJavascript('a -> b -> 1')).toEqual('export default (a$rename$16 => b$rename$17 => 1);');
   });
 
   it('translates a function expression with bindings', () => {
     expect(toJavascript('a:b -> a')).toEqual(dedent`
       export default ($PARAMETER$1 => {
-        const a$rename$102 = $PARAMETER$1;
-        const b$rename$103 = $PARAMETER$1;
-        return a$rename$102;
+        const a$rename$16 = $PARAMETER$1;
+        const b$rename$17 = $PARAMETER$1;
+        return a$rename$16;
       });
     `);
   });
@@ -78,7 +78,7 @@ describe('generateJavascript', () => {
         } else if ($patternValue === 5) {
           return "five";
         } else {
-          const _$rename$188 = $patternValue;
+          const _$rename$16 = $patternValue;
           return "something else";
         }
       })(5);
@@ -87,11 +87,11 @@ describe('generateJavascript', () => {
 
   it('translates a data declaration', () => {
     expect(toJavascript('data a = x, y, z\na 1 2 3')).toEqual(dedent`
-      const a = x$rename$210 => y$rename$211 => z$rename$212 => ({
+      const a = x$rename$16 => y$rename$17 => z$rename$18 => ({
         $DATA_NAME$: "$SYMBOL$a",
-        0: x$rename$210,
-        1: y$rename$211,
-        2: z$rename$212
+        0: x$rename$16,
+        1: y$rename$17,
+        2: z$rename$18
       });
 
       export default a(1)(2)(3);

--- a/packages/compiler/src/type-checker/type-expression.test.ts
+++ b/packages/compiler/src/type-checker/type-expression.test.ts
@@ -1,10 +1,11 @@
 import { apply, scope } from './constructors';
 import { typeExpression } from './type-check';
+import { uniqueIdStream } from './utils';
 import { VariableReplacement } from './variable-utils';
 
 describe('typeExpression', () => {
   it('infers the type of the callee to be a function', () => {
-    const { state: [_, replacements] } = typeExpression(scope())(apply('M', ['t']));
+    const { state: [_, replacements] } = typeExpression(uniqueIdStream())(scope())(apply('M', ['t']));
     const expectedReplacement: VariableReplacement = {
       from: 'M',
       to: {

--- a/packages/compiler/src/type-checker/type-utils.ts
+++ b/packages/compiler/src/type-checker/type-utils.ts
@@ -116,17 +116,11 @@ function convergeConcrete(scope: Scope, shape: Exclude<Value, FreeVariable>, chi
             return undefined;
           }
 
-          const temporaryParameter = newFreeVariable('parameter');
           const calleeReplacements = converge(scope, shape.callee, {
-            kind: 'FunctionLiteral',
-            parameter: temporaryParameter,
-            body: {
-              ...child,
-              parameters: [
-                ...child.parameters.slice(0, -1),
-                temporaryParameter,
-              ],
-            },
+            ...child,
+            parameters: [
+              ...child.parameters.slice(0, -1),
+            ],
           });
           if (!calleeReplacements) {
             return undefined;

--- a/packages/compiler/src/type-checker/type-utils.ts
+++ b/packages/compiler/src/type-checker/type-utils.ts
@@ -1,4 +1,4 @@
-import { find, flatten, map, uniqueId } from 'lodash';
+import { find, flatten, map } from 'lodash';
 import { freeVariable, scopeBinding } from './constructors';
 import { TypeResult, TypeWriter } from './monad-utils';
 import { findBinding } from './scope-utils';
@@ -13,7 +13,7 @@ import {
   SymbolLiteral,
   Value,
 } from './types/value';
-import { assertNever, checkedZip, everyIs, isDefined } from './utils';
+import { assertNever, checkedZip, everyIs, isDefined, UniqueIdGenerator } from './utils';
 import { applyReplacements, VariableReplacement } from './variable-utils';
 
 function convergeDualBinding(scope: Scope, shape: DualBinding, child: Value): VariableReplacement[] | undefined {
@@ -325,7 +325,7 @@ const applyReplacementsToScope = (scope: Scope) => (variableReplacements: Variab
 };
 
 
-export function newFreeVariable(prefix: string): FreeVariable {
-  return freeVariable(uniqueId(prefix));
+export function newFreeVariable(prefix: string, makeUniqueId: UniqueIdGenerator): FreeVariable {
+  return freeVariable(makeUniqueId(prefix));
 }
 

--- a/packages/compiler/src/type-checker/utils.ts
+++ b/packages/compiler/src/type-checker/utils.ts
@@ -224,3 +224,10 @@ export function findWithResult<T, R>(list: T[], f: (element: T) => R | undefined
 
   return [found, result]
 }
+
+export type UniqueIdGenerator = (prefix?: string) => string
+
+export function uniqueIdStream(): UniqueIdGenerator {
+  let counter = 0;
+  return prefix => `${prefix ?? ''}${++counter}`;
+}


### PR DESCRIPTION
Removes the use of persistent ids to make tests more consistent.

Fixes #35 