### PR TITLE
Fix regex in editor that hid multiline code

### DIFF
--- a/packages/compiler/src/parser/parse.test.ts
+++ b/packages/compiler/src/parser/parse.test.ts
@@ -7,6 +7,7 @@ import {
 } from '..';
 import { identifier } from '../type-checker/constructors';
 import parse from './parse';
+import dedent from 'dedent-js';
 
 describe('parse', () => {
   it('recognises a number expression', () => {
@@ -453,5 +454,30 @@ describe('parse', () => {
       },
     };
     expect(result.value).toEqual(expected);
+  });
+
+  it('parses multiple blank lines', () => {
+    const result = parse(dedent`
+      let a = 1
+      
+      
+      let b = 2
+      
+      
+      b
+    `);
+
+    expect(result.value).toEqual(expect.objectContaining({
+      kind: 'BindingExpression',
+      name: 'a',
+      body: expect.objectContaining({
+        kind: 'BindingExpression',
+        name: 'b',
+        body: {
+          kind: 'Identifier',
+          name: 'b',
+        },
+      }),
+    }));
   });
 });

--- a/packages/editor/src/app.ts
+++ b/packages/editor/src/app.ts
@@ -70,7 +70,7 @@ export default class App {
   }
 
   private generateCompilationOutput(code: string, options: CompileToOptions): CompilationOutput {
-    if (/^\s*$/m.test(code)) {
+    if (/^\s*$/.test(code)) {
       return { code: '' };
     }
 


### PR DESCRIPTION
The regular expression in the editor that hides compilation output for empty code was also skipping any code with an empty line in it. This PR fixes that so it only skips completely empty code as intended.